### PR TITLE
Improve backtest trading logic

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -1,166 +1,64 @@
 import pickle
 import numpy as np
 import matplotlib.pyplot as plt
-from sklearn.metrics import confusion_matrix, classification_report
-from train import model
+
+from tensorflow.keras.models import load_model
 from data_processing import DataProcessor
+from quantization import build_codebook
 
-"""
-Backtest configuration:
-- CSV_PATH: Path to historical data
-- N_DATAPOINTS: Number of rows to load for backtest
-- N_TESTPOINTS: Size of test window
-- WINDOW: Sequence window size for model input
-- OFFSET: Row offset to start loading data from
-- INITIAL_CAP: Starting capital for backtest
-- LEVERAGE: Trade leverage
-- RISK_PER_TRADE: % of capital risked per trade
-- STOP_LOSS_PCT, TAKE_PROFIT_PCT: SL/TP levels (percent)
-- QUANTIZER_PATH: Path to saved quantizer object
-- USE_PRICE_CHANGES: Use price returns rather than close prices if True
-"""
+CSV_PATH = "historical_data/AUDCHF_15m_historical_data.csv"
+N_DATAPOINTS = 500
+N_TESTPOINTS = 300
+WINDOW = 3
+OFFSET = 71500
+INITIAL_CAP = 10_000.0
+QUANTIZER_PATH = "quantizer.pkl"
+MODEL_PATH = "ffnn_model.keras"
+USE_PRICE_CHANGES = False
 
-CSV_PATH        = "historical_data/AUDCHF_15m_historical_data.csv"
-N_DATAPOINTS    = 500
-N_TESTPOINTS    = 300
-WINDOW          = 3
-OFFSET          = 71500
-
-INITIAL_CAP     = 5_000.0
-LEVERAGE        = 100.0 
-RISK_PER_TRADE  = 0.30
-STOP_LOSS_PCT   = 1
-TAKE_PROFIT_PCT = 1
-
-USE_PRICE_CHANGES = False  # match setting used during training
-
-QUANTIZER_PATH  = "quantizer.pkl"
-
-"""
-Load a specific window of historical OHLCV data into a DataFrame.
-"""
+# Load data
 dp = DataProcessor()
 df = dp.read_csv(CSV_PATH, n_points=N_DATAPOINTS, offset=OFFSET)
-closes        = df["Close"].values
+closes = df["Close"].values
 price_changes = dp.get_price_changes()
-highs         = df["High"].values
-lows          = df["Low"].values
-
 series = price_changes if USE_PRICE_CHANGES else closes
 
-"""
-Apply the saved quantizer to map the chosen target series to discrete labels.
-Encode labels into one-hot format for model input.
-"""
+# Load quantizer and labels
 with open(QUANTIZER_PATH, "rb") as f:
     quantizer = pickle.load(f)
+labels = quantizer.transform(series)
+M = quantizer.get_bits()
+S = build_codebook(M)
 
-labels  = quantizer.transform(series)
-one_hot = np.eye(quantizer.get_bits(), dtype=int)[labels]
+model = load_model(MODEL_PATH)
 
-TRAIN_SIZE = len(labels) - N_TESTPOINTS
-start_idx  = TRAIN_SIZE + WINDOW
+one_hot = np.eye(M, dtype=np.float32)[labels]
+start_idx = len(labels) - N_TESTPOINTS
 
-"""
-Simulate a real-time backtest over the test set.
-Predict signals bar by bar, execute trades with SL/TP logic.
-Update capital and track trade returns.
-"""
-capital       = INITIAL_CAP
-equity_curve  = [capital]
-trade_returns = []
-signals_list  = []
-prev_label    = None
+capital = INITIAL_CAP
+equity_curve = [capital]
 
-for t in range(start_idx, len(labels)-1):
-    X_in   = one_hot[t-WINDOW:t][np.newaxis, :, :]
-    y_prob = model.predict(X_in, verbose=0)[0]
-    lbl    = int(np.argmax(y_prob))
-
-    if USE_PRICE_CHANGES:
-        return_val = quantizer.inverse_transform([lbl])[0]
-        signal     = int(np.sign(return_val))
+S_T = S.T
+for t in range(start_idx, len(labels) - 1):
+    x_in = one_hot[t - WINDOW : t].reshape(1, -1)
+    out = model.predict(x_in, verbose=0)[0]
+    bits = np.where(out >= 0, 1.0, -1.0)
+    dists = ((S_T - bits) ** 2).sum(axis=1)
+    pred_lbl = int(np.argmin(dists))
+    curr_lbl = labels[t]
+    if pred_lbl > curr_lbl:
+        pos = 1
+    elif pred_lbl < curr_lbl:
+        pos = -1
     else:
-        if prev_label is None:
-            signal = 0
-        else:
-            signal = +1 if lbl > prev_label else -1 if lbl < prev_label else 0
-        prev_label = lbl
-
-    signals_list.append(signal)
-
-    if signal != 0:
-        entry = closes[t]
-        tp    = entry*(1+TAKE_PROFIT_PCT) if signal>0 else entry*(1-TAKE_PROFIT_PCT)
-        sl    = entry*(1-STOP_LOSS_PCT)   if signal>0 else entry*(1+STOP_LOSS_PCT)
-
-        hi, lo, nxt = highs[t+1], lows[t+1], closes[t+1]
-        if   signal>0 and hi  >= tp: exit_price = tp
-        elif signal<0 and lo  <= tp: exit_price = tp
-        elif signal>0 and lo  <= sl: exit_price = sl
-        elif signal<0 and hi  >= sl: exit_price = sl
-        else:                          exit_price = nxt
-
-        margin   = capital * RISK_PER_TRADE
-        notional = margin * LEVERAGE
-        units    = notional / entry
-        pnl      = units * ((exit_price-entry) if signal>0 else (entry-exit_price))
-
-        capital += pnl
-        trade_returns.append(pnl / margin)
-
+        pos = 0
+    pnl = (closes[t+1] - closes[t]) * pos
+    capital += pnl
     equity_curve.append(capital)
 
-equity_curve  = np.array(equity_curve)
-trade_returns = np.array(trade_returns)
-
-"""
-Calculate directional accuracy metrics:
-- Confusion matrix of predicted vs actual signals
-- Classification report
-- Cumulative return and max drawdown
-"""
-test_labels  = labels[TRAIN_SIZE:]
-test_series  = series[TRAIN_SIZE:]
-if USE_PRICE_CHANGES:
-    true_dirs_full = np.sign(test_series)
-else:
-    true_dirs_full = np.sign(np.diff(test_series, prepend=test_series[0]))
-true_dirs    = true_dirs_full[WINDOW:]
-pred_dirs       = np.array(signals_list)
-
-true_dirs = true_dirs[:len(pred_dirs)]
-
-cm = confusion_matrix(true_dirs, pred_dirs, labels=[-1,0,1])
-print("=== Directional Accuracy ===")
-print("Confusion Matrix (-1,0,+1):")
-print(cm)
-print("\nClassification Report:")
-print(classification_report(true_dirs, pred_dirs, labels=[-1,0,1]))
-
-cum_return = equity_curve[-1]/INITIAL_CAP - 1
-max_dd     = (equity_curve/np.maximum.accumulate(equity_curve) - 1).min()
-print(f"\n=== Performance Summary ===")
-print(f"Cumulative Return: {cum_return:.2%}")
-print(f"Max Drawdown:     {max_dd:.2%}")
-
-"""
-Visualize results:
-- Equity curve over time
-- Drawdown curve
-- Histogram of individual trade returns
-"""
-plt.figure(figsize=(10,4))
-plt.plot(equity_curve, label="Equity Curve for XAUUSD")
-plt.title("Equity Curve for XAUUSD"); plt.grid(); plt.legend()
-
-plt.figure(figsize=(10,4))
-plt.plot(equity_curve/np.maximum.accumulate(equity_curve) - 1,
-         color="red", label="Drawdown for XAUUSD")
-plt.title("Drawdown Curve for XAUUSD"); plt.grid(); plt.legend()
-
-plt.figure(figsize=(8,4))
-plt.hist(trade_returns, bins=50)
-plt.title("Distribution of Trade Returns for XAUUSD"); plt.grid()
-
+plt.figure(figsize=(10, 4))
+plt.plot(equity_curve)
+plt.title("Equity Curve")
+plt.grid()
 plt.show()
+

--- a/model.py
+++ b/model.py
@@ -1,27 +1,23 @@
-from tensorflow.python.keras.models import Sequential
-from tensorflow.python.keras.layers import Dense, Dropout
-from tensorflow.python.keras.layers.recurrent import LSTM
-from tensorflow.python.keras.callbacks import EarlyStopping
-from tensorflow.python.keras.optimizer_v2.adam import Adam
-from tensorflow.python.keras.engine import data_adapter
-from tensorflow.python.keras.regularizers import l2
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import Dense
+from tensorflow.keras.callbacks import EarlyStopping
+from tensorflow.keras.optimizer_v2.adam import Adam
+from tensorflow.keras.engine import data_adapter
 
 # Patch TensorFlow data adapter to avoid distributed dataset check errors
 def _is_distributed_dataset(ds):
     return isinstance(ds, data_adapter.input_lib.DistributedDatasetSpec)
+
 data_adapter._is_distributed_dataset = _is_distributed_dataset
 
-# Create and return a compiled LSTM model
-def create_model(input_timesteps: int, n_classes: int) -> Sequential:
+
+def create_model(input_dim: int, output_dim: int) -> Sequential:
+    """Create and compile a simple feed-forward network."""
     model = Sequential([
-        LSTM(256, activation="relu", input_shape=(input_timesteps, n_classes), return_sequences=True),
-        LSTM(256, activation="relu", return_sequences=True),
-        LSTM(128, activation="relu", return_sequences=False),
-        Dense(64, activation="relu", kernel_regularizer=l2(0.000124)),
-        Dense(64, activation="relu", kernel_regularizer=l2(0.000124)),
-        Dropout(0.2),
-        Dense(n_classes, activation="softmax")
+        Dense(64, activation="relu", input_shape=(input_dim,)),
+        Dense(output_dim)
     ])
-    optimizer = Adam(learning_rate=0.000285)
-    model.compile(optimizer=optimizer, loss="categorical_crossentropy", metrics=["accuracy"])
+    optimizer = Adam(learning_rate=0.001)
+    model.compile(optimizer=optimizer, loss="mse")
     return model
+

--- a/quantization.py
+++ b/quantization.py
@@ -1,4 +1,5 @@
 import numpy as np
+import math
 
 
 class Quantization:
@@ -73,3 +74,14 @@ class Quantization:
         centers = (self.bin_edges[:-1] + self.bin_edges[1:]) / 2.0
         codes = np.clip(codes, 0, self.n_bits - 1)
         return centers[codes]
+
+
+def build_codebook(n_bins: int) -> np.ndarray:
+    """Return an L x M codebook splitting bins hierarchically."""
+    L = int(math.ceil(math.log2(n_bins)))
+    S = np.empty((L, n_bins), dtype=np.float32)
+    for m in range(n_bins):
+        for l in range(L):
+            bit = (m >> (L - l - 1)) & 1
+            S[l, m] = 1.0 if bit == 0 else -1.0
+    return S

--- a/train.py
+++ b/train.py
@@ -1,129 +1,108 @@
 import numpy as np
 import pickle
-from sklearn.metrics import confusion_matrix, classification_report, accuracy_score, ConfusionMatrixDisplay
+from sklearn.metrics import confusion_matrix, classification_report, accuracy_score
+from sklearn.model_selection import train_test_split
 import matplotlib.pyplot as plt
 
 from data_processing import DataProcessor
-from quantization import Quantization
-from x_y_arrays import x_y_arrays
-from model import create_model, EarlyStopping
+from quantization import Quantization, build_codebook
+from model import create_model
+from tensorflow.keras.callbacks import EarlyStopping
 
-"""
-Configuration:
-- CSV_PATH: Path to historical data
-- N_DATAPOINTS: Number of rows to load
-- N_TESTPOINTS: Holdout size for backtesting
-- WINDOW: Model input sequence length
-- TEST_SIZE: Validation split ratio
-- BATCH_SIZE: Training batch size
-- EPOCHS: Training epochs
-- OFFSET: Data window starting row
-- N_BITS: Quantization levels
-- BIN_SIZE: Quantization bin width (in currency units)
-- QUANTIZER_OUT: Saved quantizer file
-- USE_PRICE_CHANGES: If True, quantize 1-step price returns instead of closes
-"""
-
-CSV_PATH      = "historical_data/AUDCHF_15m_historical_data.csv"
-N_DATAPOINTS  = 500
-N_TESTPOINTS  = 300
-WINDOW        = 3
-TEST_SIZE     = 0.2
-BATCH_SIZE    = 64
-EPOCHS        = 100
-OFFSET        = 71500
-N_BITS        = 25
-BIN_SIZE      = 0.001
-USE_PRICE_CHANGES = False  # Toggle between price or return quantization
-
+# Configuration
+CSV_PATH = "historical_data/AUDCHF_15m_historical_data.csv"
+N_DATAPOINTS = 500
+N_TESTPOINTS = 300
+WINDOW = 3
+TEST_SIZE = 0.2
+BATCH_SIZE = 64
+EPOCHS = 100
+OFFSET = 71500
+BIN_SIZE = 0.001
+USE_PRICE_CHANGES = False
 QUANTIZER_OUT = "quantizer.pkl"
 
-"""
-Load a segment of historical OHLCV data into a DataFrame.
-"""
+# Load data
 dp = DataProcessor()
 df = dp.read_csv(CSV_PATH, n_points=N_DATAPOINTS, offset=OFFSET)
-closes        = dp.get_close_prices()
+closes = dp.get_close_prices()
 price_changes = dp.get_price_changes()
-
-print(min(price_changes))
-
 series = price_changes if USE_PRICE_CHANGES else closes
 
-"""
-Fit quantizer on training data and transform the full dataset.
-"""
+# Fit quantizer
 TRAIN_SIZE = (len(series) if USE_PRICE_CHANGES else N_DATAPOINTS) - N_TESTPOINTS
 quantizer = Quantization(bin_size=BIN_SIZE)
 quantizer.fit(series[:TRAIN_SIZE])
-num_classes = quantizer.get_bits()
-
+M = quantizer.get_bits()
 labels = quantizer.transform(series)
-
 with open(QUANTIZER_OUT, "wb") as f:
     pickle.dump(quantizer, f)
 
-"""
-Prepare one-hot encoded sequences and labels for model training.
-"""
-one_hot = np.eye(num_classes, dtype=int)[labels[:TRAIN_SIZE]]
-labels_train  = labels[:TRAIN_SIZE]
+# Build codebook
+S = build_codebook(M)
+L = S.shape[0]
 
-xy = x_y_arrays(
-    df=one_hot,
-    target=labels_train,
-    n=WINDOW,
-    test_size=TEST_SIZE,
-    shuffle=True,
-    random_state=42,
-    num_classes=num_classes
+# Build training sequences
+one_hot = np.eye(M, dtype=np.float32)[labels[:TRAIN_SIZE]]
+X_all = []
+Y_all = []
+label_targets = []
+for t in range(WINDOW, TRAIN_SIZE):
+    X_all.append(one_hot[t-WINDOW:t].reshape(-1))
+    Y_all.append(S[:, labels[t]])
+    label_targets.append(labels[t])
+X_all = np.stack(X_all)
+Y_all = np.stack(Y_all)
+label_targets = np.array(label_targets)
+
+# Train/validation split
+X_train, X_val, Y_train, Y_val, lbl_train, lbl_val = train_test_split(
+    X_all, Y_all, label_targets, test_size=TEST_SIZE, shuffle=True, random_state=42
 )
-X_train, X_val, Y_train, Y_val = xy.get_train_test()
 print(f"X_train shape: {X_train.shape}, Y_train shape: {Y_train.shape}")
 
-"""
-Define LSTM model, configure early stopping, and train.
-"""
-model = create_model(input_timesteps=WINDOW, n_classes=num_classes)
+# Model
+model = create_model(input_dim=WINDOW * M, output_dim=L)
 early = EarlyStopping(monitor="val_loss", patience=10, restore_best_weights=True)
-
-history = model.fit(
-    X_train, Y_train,
+model.fit(
+    X_train,
+    Y_train,
     validation_data=(X_val, Y_val),
     epochs=EPOCHS,
     batch_size=BATCH_SIZE,
     callbacks=[early],
-    verbose=1
+    verbose=1,
 )
 
-"""
-Evaluate model accuracy, confusion matrix, and classification report.
-"""
-y_probs = model.predict(X_val, batch_size=BATCH_SIZE, verbose=0)
-y_pred  = np.argmax(y_probs, axis=1)
-y_true  = np.argmax(Y_val, axis=1)
+# Evaluation
+preds = model.predict(X_val, batch_size=BATCH_SIZE, verbose=0)
+bit_preds = np.where(preds >= 0, 1.0, -1.0)
+S_T = S.T
+label_preds = []
+for bp in bit_preds:
+    dists = ((S_T - bp) ** 2).sum(axis=1)
+    label_preds.append(int(np.argmin(dists)))
+label_preds = np.array(label_preds)
 
-acc = accuracy_score(y_true, y_pred)
+acc = accuracy_score(lbl_val, label_preds)
 print(f"\nValidation accuracy: {acc:.4f}\n")
-
-all_labels = np.arange(num_classes)
-conf_mat = confusion_matrix(y_true, y_pred, labels=all_labels)
+conf_mat = confusion_matrix(lbl_val, label_preds, labels=np.arange(M))
 print("Confusion Matrix:")
 print(conf_mat, "\n")
-
 print("Classification Report:")
-print(classification_report(y_true, y_pred, labels=all_labels, digits=4))
-
-"""
-Visualize the confusion matrix as a heatmap.
-"""
+print(classification_report(lbl_val, label_preds, labels=np.arange(M), digits=4))
 
 plt.figure(figsize=(8, 6))
-plt.imshow(conf_mat, aspect='auto')
-plt.title('Confusion Matrix')
-plt.xlabel('Predicted Label')
-plt.ylabel('True Label')
+plt.imshow(conf_mat, aspect="auto")
+plt.title("Confusion Matrix")
+plt.xlabel("Predicted Label")
+plt.ylabel("True Label")
 plt.colorbar()
 plt.tight_layout()
 plt.show()
+
+# Save model for backtesting
+MODEL_OUT = "ffnn_model.keras"
+model.save(MODEL_OUT)
+print(f"Model saved to {MODEL_OUT}")
 


### PR DESCRIPTION
## Summary
- load saved model in the backtester instead of importing from `train`
- infer predicted label from codebook distance for more trading activity
- persist trained FFNN to `ffnn_model.keras`
